### PR TITLE
Guard correction history from overflowing staticEval in the future

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -93,6 +93,11 @@ constexpr int futility_move_count(bool improving, Depth depth) {
     return improving ? (3 + depth * depth) : (3 + depth * depth) / 2;
 }
 
+// Guarantee evaluation does not hit the tablebase range
+constexpr Value to_static_eval(const Value v) {
+    return std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+}
+
 // History and stats update bonus, based on depth
 int stat_bonus(Depth d) { return std::min(268 * d - 352, 1153); }
 
@@ -719,7 +724,7 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     {
         // Skip early pruning when in check
         unadjustedStaticEval = ss->staticEval = eval = VALUE_NONE;
-        improving             = false;
+        improving                                    = false;
         goto moves_loop;
     }
     else if (excludedMove)
@@ -738,7 +743,9 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
         else if (PvNode)
             Eval::NNUE::hint_common_parent_position(pos);
 
-        ss->staticEval = eval = ss->staticEval + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16);
+        ss->staticEval = eval = to_static_eval(
+          ss->staticEval
+          + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16));
 
         // ttValue can be used as a better position evaluation (~7 Elo)
         if (ttValue != VALUE_NONE && (tte->bound() & (ttValue > eval ? BOUND_LOWER : BOUND_UPPER)))
@@ -748,10 +755,13 @@ Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, boo
     {
         unadjustedStaticEval = ss->staticEval = eval = evaluate(pos);
 
-        ss->staticEval = eval = ss->staticEval + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16);
+        ss->staticEval = eval = to_static_eval(
+          ss->staticEval
+          + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16));
         // Save static evaluation into the transposition table
         // Static evaluation is saved as it was before adjustment by correction history
-        tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE, unadjustedStaticEval);
+        tte->save(posKey, VALUE_NONE, ss->ttPv, BOUND_NONE, DEPTH_NONE, MOVE_NONE,
+                  unadjustedStaticEval);
     }
 
     // Use static evaluation difference to improve quiet move ordering (~4 Elo)
@@ -1380,14 +1390,12 @@ moves_loop:  // When in check, search starts here
                   depth, bestMove, unadjustedStaticEval);
 
     // Adjust correction history
-    if (!ss->inCheck
-        && (!bestMove || !pos.capture(bestMove))
+    if (!ss->inCheck && (!bestMove || !pos.capture(bestMove))
         && !(bestValue >= beta && bestValue <= ss->staticEval)
         && !(!bestMove && bestValue >= ss->staticEval))
-        thisThread->correctionHistory[us][correction_pawn_structure(pos)] << 
-            std::clamp(int(bestValue - ss->staticEval) * (16 + depth) / 32,
-                       -CORRECTION_HISTORY_LIMIT / 2,
-                        CORRECTION_HISTORY_LIMIT / 2);
+        thisThread->correctionHistory[us][correction_pawn_structure(pos)]
+          << std::clamp(int(bestValue - ss->staticEval) * (16 + depth) / 32,
+                        -CORRECTION_HISTORY_LIMIT / 2, CORRECTION_HISTORY_LIMIT / 2);
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 
@@ -1481,7 +1489,9 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
             if ((unadjustedStaticEval = ss->staticEval = bestValue = tte->eval()) == VALUE_NONE)
                 unadjustedStaticEval = ss->staticEval = bestValue = evaluate(pos);
 
-            ss->staticEval = bestValue = ss->staticEval + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16);
+            ss->staticEval = bestValue = to_static_eval(
+              ss->staticEval
+              + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16));
 
             // ttValue can be used as a better position evaluation (~13 Elo)
             if (ttValue != VALUE_NONE
@@ -1493,7 +1503,9 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
             // In case of null move search, use previous static eval with a different sign
             unadjustedStaticEval = ss->staticEval = bestValue =
               (ss - 1)->currentMove != MOVE_NULL ? evaluate(pos) : -(ss - 1)->staticEval;
-            ss->staticEval = bestValue = ss->staticEval + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16);
+            ss->staticEval = bestValue = to_static_eval(
+              ss->staticEval
+              + Value(thisThread->correctionHistory[us][correction_pawn_structure(pos)] / 16));
         }
 
         // Stand pat. Return immediately if static value is at least beta
@@ -1647,7 +1659,8 @@ Value qsearch(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth) {
     // Save gathered info in transposition table
     // Static evaluation is saved as it was before adjustment by correction history
     tte->save(posKey, value_to_tt(bestValue, ss->ply), pvHit,
-              bestValue >= beta ? BOUND_LOWER : BOUND_UPPER, ttDepth, bestMove, unadjustedStaticEval);
+              bestValue >= beta ? BOUND_LOWER : BOUND_UPPER, ttDepth, bestMove,
+              unadjustedStaticEval);
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 


### PR DESCRIPTION
Adds clamping to staticEval to guard for future tweaks hitting TB range or mate range.

Passed non-regression STC:
https://tests.stockfishchess.org/tests/view/65903fe179aa8af82b9566fb
LLR: 2.98 (-2.94,2.94) <-1.75,0.25>
Total: 38656 W: 10048 L: 9830 D: 18778
Ptnml(0-2): 124, 4278, 10308, 4492, 126

Passed non-regression LTC:
https://tests.stockfishchess.org/tests/view/659055d079aa8af82b95691d
LLR: 2.94 (-2.94,2.94) <-1.75,0.25>
Total: 134532 W: 33728 L: 33625 D: 67179
Ptnml(0-2): 70, 14326, 38369, 14433, 68

no functional change